### PR TITLE
Route53 changeset + Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,54 @@
 
 This project will contain the code and configuration to deploy various Cloudformation custom resources.
 
-Here is a list of the
+## Custom resources
 
-1. [Lookup AMI by Name](lookup-ami/README.md)
-1. [Lookup NS records by domain name](lookup-ns-records/README.md)
+### S3 Bucket cleanup
+
+Removes all keys within a bucket. Role assumed by Lambda needs to have appropriate 
+permissions to remove bucket keys, commonly set through Bucket policies.  
+Cleanup logic is implemented in 'DELETE' action. 'CREATE' and 'UPDATE'
+actions are just dummy stubs.
+
+handler: `src/cleanup-s3-bucket/index.handler`
+
+Required parameters: 
+- `BucketName` - String. Name of the bucket that should have it's keys cleaned up
+
+
+
+
+### ENI Cleanup
+
+Detaches (if requiered) and deletes all ENIs within specified subnets.
+Cleanup logic is implemented in 'DELETE' action. 'CREATE' and 'UPDATE'
+actions are just dummy stubs.
+
+handler: `src/cleanup-subnet-enis/index.hanlder`
+
+Required parameters:
+- `SubnetIds` - Array of Strings. Self explanitory - all subnets within this area
+shall have their ENI's cleaned up on stack deletion
+
+
+### Route 53 DNS Records creation
+
+Creates, Updates and Cleans up Rotue53 DNS records in specified zone. All
+operations are done using assumed role that is passed down as Custom Resource
+parameters
+
+handler: `src/route53-changeset/index.handler`
+
+Required parameters:
+- `role` - ARN of role that should be assumed by Custom Resource. It's assumed
+that user would just directly create Route53 records using supported resource 
+types in same account where stack resides - so this is mandaroty parameter, as
+custom resource is intended to be used for managing records in account diferent 
+from where stack is being created. This custom resource is making appropriate API calls 
+for all 3 operations - CREATE, UPDATE and DELETE. 
+
+- `recordset` - json object with following properties
+- - `ttl` - TTL for recrod set
+- - `zoneId` - Route53 zone id where record should be created (PRs welcome to move from zoneId to ZoneName)
+- - `type` - DNS Record type, e.g. `A`, `CNAME` ...
+- - `value` - Actual value of DNS record

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cloudformation-custom-resouces",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "base2 custom cloudformation resources",
     "private": "true",
     "devDependencies": {

--- a/src/route53-changeset/index.js
+++ b/src/route53-changeset/index.js
@@ -1,0 +1,50 @@
+/**
+ * A Lambda function that looks up a AMI ID for a given ami name.
+ **/
+
+const CfnLambda = require('cfn-lambda');
+const ManageRecordSet = require('./manageRecordSet');
+
+// create records
+var Create = (cfnRequestParams, reply) => {
+    let route53ManageLogic = new ManageRecordSet(
+        cfnRequestParams.role,
+        cfnRequestParams.recordset,
+        function(err, data) {
+            reply(err, cfnRequestParams.recordset.name);
+        }
+    );
+    route53ManageLogic.create()
+};
+
+//considering UPSERT command behaviour, create and update are nearly the same
+var Update = (requestPhysicalID, cfnRequestParams, oldCfnRequestParams, reply) => {
+    let route53ManageLogic = new ManageRecordSet(
+        cfnRequestParams.role,
+        cfnRequestParams.recordset,
+        function(err, data) {
+            reply(err, requestPhysicalID);
+        }
+    );
+    route53ManageLogic.create();
+};
+
+//Remove route53 records
+var Delete = (requestPhysicalID, cfnRequestParams, reply) => {
+    let route53ManageLogic = new ManageRecordSet(
+        cfnRequestParams.role,
+        cfnRequestParams.recordset,
+        function(err, data) {
+            reply(err, requestPhysicalID);
+        }
+    );
+    route53ManageLogic.delete();
+};
+
+exports.handler = CfnLambda({
+    Create: Create,
+    Update: Update,
+    Delete: Delete,
+    TriggersReplacement: []
+        // SchemaPath: [__dirname, 'schema.json']
+});

--- a/src/route53-changeset/manageRecordSet.js
+++ b/src/route53-changeset/manageRecordSet.js
@@ -1,0 +1,98 @@
+const AWS = require('aws-sdk');
+
+class ManageRecordSet {
+
+    constructor(role, recordset, handler) {
+        this.role = role;
+        this.recordset = recordset;
+        this.handler = handler;
+    }
+
+    changeSetHandler() {
+        var self = this;
+        return (err, data) => {
+            if (err) {
+                console.error(err);
+                self.handler(err);
+                return;
+            }
+            console.log(`Change ${data.ChangeInfo.Id}`);
+            console.log(`Status ${data.ChangeInfo.Status}`);
+            self.handler(null, null);
+        }
+    }
+
+    doRecordSetChange(route53, action) {
+        let self = this;
+        route53.changeResourceRecordSets({
+            HostedZoneId: self.recordset.zoneId,
+            ChangeBatch: {
+                Comment: 'This change was made by lambda backed Custom Resource',
+                Changes: [{
+                    Action: action,
+                    ResourceRecordSet: {
+                        Name: self.recordset.name,
+                        TTL: self.recordset.ttl,
+                        Type: self.recordset.type,
+                        ResourceRecords: [{
+                            Value: self.recordset.value
+                        }]
+                    }
+                }]
+            }
+        }, self.changeSetHandler());
+    }
+
+    create() {
+        let self = this;
+        self.assumeRole(function(err, data) {
+            if (err) {
+                console.error(err);
+                self.handler(err);
+                return;
+            }
+            let route53 = data != null ? new AWS.Route53({
+                apiVersion: '2013-04-01',
+                accessKeyId: data.Credentials.AccessKeyId,
+                secretAccessKey: data.Credentials.SecretAccessKey,
+                sessionToken: data.Credentials.SessionToken
+            }) : new AWS.Route53({ apiVersion: '2013-04-01' });
+
+            self.doRecordSetChange.call(self, route53, 'UPSERT');
+        });
+    }
+
+    delete() {
+        let self = this;
+        self.assumeRole(function(err, data) {
+            if (err) {
+                console.error(err);
+                self.handler(err);
+                return;
+            }
+            let route53 = data != null ? new AWS.Route53({
+                apiVersion: '2013-04-01',
+                accessKeyId: data.Credentials.AccessKeyId,
+                secretAccessKey: data.Credentials.SecretAccessKey,
+                sessionToken: data.Credentials.SessionToken
+            }) : new AWS.Route53({ apiVersion: '2013-04-01' });
+
+            self.doRecordSetChange.call(self, route53, 'DELETE');
+        });
+    }
+
+    assumeRole(callback) {
+        let self = this;
+        if (self.role) {
+            let sts = new AWS.STS({ apiVersion: '2011-06-15' });
+            sts.assumeRole({
+                    RoleArn: self.role,
+                    RoleSessionName: `lambdafn-${process.env.awsRequestId}`
+                },
+                callback);
+        } else callback.call(self, null, null);
+    }
+
+}
+
+module.exports = ManageRecordSet;


### PR DESCRIPTION

### Route 53 DNS Records creation

Creates, Updates and Cleans up Rotue53 DNS records in specified zone. All
operations are done using assumed role that is passed down as Custom Resource
parameters

handler: `src/route53-changeset/index.handler`

Required parameters:
- `role` - ARN of role that should be assumed by Custom Resource. It's assumed
that user would just directly create Route53 records using supported resource 
types in same account where stack resides - so this is mandaroty parameter, as
custom resource is intended to be used for managing records in account diferent 
from where stack is being created. This custom resource is making appropriate API calls 
for all 3 operations - CREATE, UPDATE and DELETE. 

- `recordset` - json object with following properties
- - `ttl` - TTL for recrod set
- - `zoneId` - Route53 zone id where record should be created (PRs welcome to move from zoneId to ZoneName)
- - `type` - DNS Record type, e.g. `A`, `CNAME` ...
- - `value` - Actual value of DNS record